### PR TITLE
Land five LineGroupClass accessor bodies at 0x001B35F0-0x001B36B0

### DIFF
--- a/Code/Libraries/Source/WWVegas/WW3D2/linegrp.cpp
+++ b/Code/Libraries/Source/WWVegas/WW3D2/linegrp.cpp
@@ -131,6 +131,7 @@ void LineGroupClass::Set_Arrays(
 
 }
 
+// ?Set_Line_Size@LineGroupClass@@QAEXM@Z present-unmatched
 void LineGroupClass::Set_Line_Size(float size)
 {
 	DefaultLineSize = size;

--- a/Code/Libraries/Source/WWVegas/WW3D2/linegrp.cpp
+++ b/Code/Libraries/Source/WWVegas/WW3D2/linegrp.cpp
@@ -162,6 +162,7 @@ Vector4 LineGroupClass::Get_Tail_Diffuse(void)
 	return DefaultTailDiffuse;
 }
 
+// ?Set_Line_Alpha@LineGroupClass@@QAEXM@Z present-unmatched
 void LineGroupClass::Set_Line_Alpha(float alpha)
 {
 	DefaultLineAlpha = alpha;

--- a/Code/Libraries/Source/WWVegas/WW3D2/linegrp_float_setters.cpp
+++ b/Code/Libraries/Source/WWVegas/WW3D2/linegrp_float_setters.cpp
@@ -1,0 +1,23 @@
+// cl: /arch:SSE /Ireference/shims/bfmerendobj /DNDEBUG /MD /Ireference/open-bfme-1/Code/Libraries/Source/WWVegas/WWMath /Ireference/open-bfme-1/Code/Libraries/Source/WWVegas/WWLib /Ireference/open-bfme-1/Code/Libraries/Source/WWVegas/WWSaveLoad /Ireference/open-bfme-1/Code/Libraries/Source/WWVegas/WW3D2 /Ireference/open-bfme-1/Code/Libraries/Source/WWVegas/Wwutil /Ireference/open-bfme-1/Code/Libraries/Source/WWVegas/WWDownload /Ireference/open-bfme-1/Code/Libraries/Source/Compression /Ireference/open-bfme-1/Code/Libraries/Source/WWVegas/WWDebug /Ireference/shims/sweep /Ireference/open-bfme-1/Code/Libraries/Source/WWVegas/WWLib /Ireference/open-bfme-1/Code/Libraries/Source/WWVegas/WW3D2 /Ireference/open-bfme-1/Code/Libraries/Source/WWVegas/WWMath /Ireference/open-bfme-1/Code/Libraries/Source/WWVegas/WWSaveLoad /Ireference/open-bfme-1/Code/Libraries/Source/WWVegas/Wwutil /Ireference/open-bfme-1/Code/Libraries/Source/WWVegas/WWDownload /Ireference/open-bfme-1/Code/Libraries/Source/WWVegas/WWDebug /Ireference/open-bfme-1/Code/Libraries/Source/Compression /Ireference/shims/sweep
+// LineGroupClass::Set_Line_Size and ::Set_Line_Alpha, split out of linegrp.cpp
+// because retail stores both floats with movss.  The rest of the accessor block
+// in that unit is integer struct copies, which compile the same either way, but
+// linegrp.cpp cannot carry /arch:SSE while the ?Set_Line_UCoord row it also owns
+// claims the x87-era twin at 0x0041FDEE; the two float setters therefore live
+// here, where the flag costs nothing else.
+//
+// Retail 0x001B35F0 is movss xmm0,[esp+4] / movss [ecx+0x30],xmm0 / ret 4 and
+// 0x001B3690 is the same shape against [ecx+0x40] -- DefaultLineSize and
+// DefaultLineAlpha at the offsets linegrp.h already gives them, confirmed by the
+// neighbouring landed rows (Set_Line_Color at +0x34, Set_Tail_Diffuse at +0x48).
+#include "linegrp.h"
+
+void LineGroupClass::Set_Line_Size(float size)
+{
+	DefaultLineSize = size;
+}
+
+void LineGroupClass::Set_Line_Alpha(float alpha)
+{
+	DefaultLineAlpha = alpha;
+}

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -5631,3 +5631,4 @@ _piCallbacksCleanup,,0x0069EEF0,24,Code/GameEngine/Source/GameNetwork/GameSpy/pe
 ??0?$DynamicVectorClass@PAVRender2DClass@@@@QAE@IPBQAVRender2DClass@@@Z,,0x001A3AE0,94,Code/Libraries/Source/WWVegas/WW3D2/render2dsentence.cpp,matched,ported from BFME1; exact folded-body identity
 ??_G?$VectorClass@PAVVertexMaterialClass@@@@UAEPAXI@Z,,0x001A3B90,71,Code/Libraries/Source/WWVegas/WW3D2/matinfo.cpp,matched,ported from BFME1; exact folded-body identity
 ?Set_Line_Size@LineGroupClass@@QAEXM@Z,,0x001B35F0,14,Code/Libraries/Source/WWVegas/WW3D2/linegrp_float_setters.cpp,matched,reloc-named unclaimed; retail stores the float with movss so this split TU carries /arch:SSE
+?Set_Line_Alpha@LineGroupClass@@QAEXM@Z,,0x001B3690,14,Code/Libraries/Source/WWVegas/WW3D2/linegrp_float_setters.cpp,matched,reloc-named unclaimed; movss into DefaultLineAlpha at +0x40 under /arch:SSE

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -5630,3 +5630,4 @@ _piCallbacksCleanup,,0x0069EEF0,24,Code/GameEngine/Source/GameNetwork/GameSpy/pe
 ??0?$DynamicVectorClass@PAVFontCharsBuffer@@@@QAE@IPBQAVFontCharsBuffer@@@Z,,0x001A3AE0,94,Code/Libraries/Source/WWVegas/WW3D2/render2dsentence.cpp,matched,ported from BFME1; exact folded-body identity
 ??0?$DynamicVectorClass@PAVRender2DClass@@@@QAE@IPBQAVRender2DClass@@@Z,,0x001A3AE0,94,Code/Libraries/Source/WWVegas/WW3D2/render2dsentence.cpp,matched,ported from BFME1; exact folded-body identity
 ??_G?$VectorClass@PAVVertexMaterialClass@@@@UAEPAXI@Z,,0x001A3B90,71,Code/Libraries/Source/WWVegas/WW3D2/matinfo.cpp,matched,ported from BFME1; exact folded-body identity
+?Set_Line_Size@LineGroupClass@@QAEXM@Z,,0x001B35F0,14,Code/Libraries/Source/WWVegas/WW3D2/linegrp_float_setters.cpp,matched,reloc-named unclaimed; retail stores the float with movss so this split TU carries /arch:SSE

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -5633,3 +5633,4 @@ _piCallbacksCleanup,,0x0069EEF0,24,Code/GameEngine/Source/GameNetwork/GameSpy/pe
 ?Set_Line_Size@LineGroupClass@@QAEXM@Z,,0x001B35F0,14,Code/Libraries/Source/WWVegas/WW3D2/linegrp_float_setters.cpp,matched,reloc-named unclaimed; retail stores the float with movss so this split TU carries /arch:SSE
 ?Set_Line_Alpha@LineGroupClass@@QAEXM@Z,,0x001B3690,14,Code/Libraries/Source/WWVegas/WW3D2/linegrp_float_setters.cpp,matched,reloc-named unclaimed; movss into DefaultLineAlpha at +0x40 under /arch:SSE
 ?Get_Line_Size@LineGroupClass@@QAEMXZ,,0x001B3600,4,Code/Libraries/Source/WWVegas/WW3D2/linegrp.cpp,matched,x87 float return so the flag split does not apply; sits in the LineGroupClass COMDAT run between the landed Set_Line_Size and Set_Line_Color
+?Get_Line_Alpha@LineGroupClass@@QAEMXZ,,0x001B36A0,4,Code/Libraries/Source/WWVegas/WW3D2/linegrp.cpp,matched,fld from DefaultLineAlpha at +0x40; next slot after the landed Set_Line_Alpha in the same COMDAT run

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -5634,3 +5634,4 @@ _piCallbacksCleanup,,0x0069EEF0,24,Code/GameEngine/Source/GameNetwork/GameSpy/pe
 ?Set_Line_Alpha@LineGroupClass@@QAEXM@Z,,0x001B3690,14,Code/Libraries/Source/WWVegas/WW3D2/linegrp_float_setters.cpp,matched,reloc-named unclaimed; movss into DefaultLineAlpha at +0x40 under /arch:SSE
 ?Get_Line_Size@LineGroupClass@@QAEMXZ,,0x001B3600,4,Code/Libraries/Source/WWVegas/WW3D2/linegrp.cpp,matched,x87 float return so the flag split does not apply; sits in the LineGroupClass COMDAT run between the landed Set_Line_Size and Set_Line_Color
 ?Get_Line_Alpha@LineGroupClass@@QAEMXZ,,0x001B36A0,4,Code/Libraries/Source/WWVegas/WW3D2/linegrp.cpp,matched,fld from DefaultLineAlpha at +0x40; next slot after the landed Set_Line_Alpha in the same COMDAT run
+?Get_Line_UCoord@LineGroupClass@@QAEMXZ,,0x001B36B0,4,Code/Libraries/Source/WWVegas/WW3D2/linegrp.cpp,matched,fld from DefaultLineUCoord at +0x44; the setter beside it is the one COMDAT in this run the linker folded away

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -5632,3 +5632,4 @@ _piCallbacksCleanup,,0x0069EEF0,24,Code/GameEngine/Source/GameNetwork/GameSpy/pe
 ??_G?$VectorClass@PAVVertexMaterialClass@@@@UAEPAXI@Z,,0x001A3B90,71,Code/Libraries/Source/WWVegas/WW3D2/matinfo.cpp,matched,ported from BFME1; exact folded-body identity
 ?Set_Line_Size@LineGroupClass@@QAEXM@Z,,0x001B35F0,14,Code/Libraries/Source/WWVegas/WW3D2/linegrp_float_setters.cpp,matched,reloc-named unclaimed; retail stores the float with movss so this split TU carries /arch:SSE
 ?Set_Line_Alpha@LineGroupClass@@QAEXM@Z,,0x001B3690,14,Code/Libraries/Source/WWVegas/WW3D2/linegrp_float_setters.cpp,matched,reloc-named unclaimed; movss into DefaultLineAlpha at +0x40 under /arch:SSE
+?Get_Line_Size@LineGroupClass@@QAEMXZ,,0x001B3600,4,Code/Libraries/Source/WWVegas/WW3D2/linegrp.cpp,matched,x87 float return so the flag split does not apply; sits in the LineGroupClass COMDAT run between the landed Set_Line_Size and Set_Line_Color


### PR DESCRIPTION
Five LineGroupClass accessor bodies, converted from the byte-true dump to
clean C++ and byte-verified one at a time.

| RVA | size | symbol |
|---|---|---|
| 0x001B35F0 | 14 | `Set_Line_Size` |
| 0x001B3600 |  4 | `Get_Line_Size` |
| 0x001B3690 | 14 | `Set_Line_Alpha` |
| 0x001B36A0 |  4 | `Get_Line_Alpha` |
| 0x001B36B0 |  4 | `Get_Line_UCoord` |

### Identity

All five sit in one COMDAT run, 0x001B35F0..0x001B3730, which follows
`linegrp.h`'s declaration order against the exact member offsets that header
gives: Flags +0x2C, DefaultLineSize +0x30, DefaultLineColor +0x34,
DefaultLineAlpha +0x40, DefaultLineUCoord +0x44, DefaultTailDiffuse +0x48,
LineMode +0x58. Four LineGroupClass rows were already landed inside that same
run (`Set_Line_Color`, `Get_Line_Color`, `Set_Tail_Diffuse`, `Get_Tail_Diffuse`),
so each new body is bracketed by proven neighbours rather than named from its
shape alone.

### Why the split TU

Retail stores both floats with `movss`, so `Set_Line_Size` and `Set_Line_Alpha`
only compile at `/arch:SSE`. `linegrp.cpp` cannot carry that flag while row 4276
(`?Set_Line_UCoord@LineGroupClass@@QAEXM@Z` @ 0x0041FDEE) is live: under
`/arch:SSE` every row in the unit still verified *except* that one. The two float
setters therefore live in `linegrp_float_setters.cpp`, which carries the flag
alone; the three `fld` getters return in st0 either way and stay in `linegrp.cpp`,
marked `present-unmatched` where the old definitions remain.

That 0x0041FDEE row is worth someone else's second look — the evidence now
points at it holding a non-SSE twin rather than LineGroupClass's own body, whose
COMDAT the linker folded away (0x001B36A4..0x001B36AF is int3 padding where
`Set_Line_UCoord` belongs). Two SSE-form candidates exist, 0x00179010 and
0x002628F9, so it is ambiguous and this PR does not touch it.

### Verification

- `conversion_gate.py origin/master HEAD` — clean, no naked/`__emit` anywhere
- `delta_sources.py` names `linegrp.cpp` and `linegrp_float_setters.cpp`
- `./build.sh` on both — 12/12 matched
- swept the 12 rows against the whole ledger: no overlapping or duplicate range

### Heads-up: `check_csv` is red before this branch

`tools/verify_pr.sh` gates on `check_csv.py` first and will fail there. None of
it comes from this PR — the tree is already red at `91e3aef8`:

- `??0SupplyWarehouseDockUpdateModuleData@@QAE@XZ` @ 0x004A7FF0 resurrected by a
  union merge from a branch that forked before its delete
- four rows added at `91e3aef8` naming `Code/GameEngine/Source/Common/BfmeConv692.cpp`,
  `BfmeConv693.cpp`, `BfmeConv695.cpp` and `BfmeTwoHundredNinetySix.cpp`, none of
  which were committed

The second one also stops `tools/progress.py` from running at all
(`cannot read matched source .../BfmeConv693.cpp`), which is why no progress
figure is quoted above.
