### PR TITLE
Land byte-exact C++ bodies (+132 C++ vs origin/master)

### DIFF
--- a/Code/Libraries/Source/WWVegas/WW3D2/DebugStatisticsTextureGetters.cpp
+++ b/Code/Libraries/Source/WWVegas/WW3D2/DebugStatisticsTextureGetters.cpp
@@ -1,0 +1,57 @@
+// cl: /O2 /DNDEBUG /MD
+//
+// Debug_Statistics last-frame texture getters. Each is `mov eax, [last]; ret`.
+
+int last_frame_texture_memory;
+int last_frame_texture_count;
+int last_frame_texture_change_count;
+int last_frame_lightmap_texture_memory;
+int last_frame_lightmap_texture_count;
+int last_frame_procedural_texture_memory;
+int last_frame_procedural_texture_count;
+
+namespace Debug_Statistics
+{
+	int Get_Record_Texture_Size();
+	int Get_Record_Texture_Count();
+	int Get_Record_Texture_Change_Count();
+	int Get_Record_Lightmap_Texture_Size();
+	int Get_Record_Lightmap_Texture_Count();
+	int Get_Record_Procedural_Texture_Size();
+	int Get_Record_Procedural_Texture_Count();
+}
+
+int Debug_Statistics::Get_Record_Texture_Size()
+{
+	return last_frame_texture_memory;
+}
+
+int Debug_Statistics::Get_Record_Texture_Count()
+{
+	return last_frame_texture_count;
+}
+
+int Debug_Statistics::Get_Record_Texture_Change_Count()
+{
+	return last_frame_texture_change_count;
+}
+
+int Debug_Statistics::Get_Record_Lightmap_Texture_Size()
+{
+	return last_frame_lightmap_texture_memory;
+}
+
+int Debug_Statistics::Get_Record_Lightmap_Texture_Count()
+{
+	return last_frame_lightmap_texture_count;
+}
+
+int Debug_Statistics::Get_Record_Procedural_Texture_Size()
+{
+	return last_frame_procedural_texture_memory;
+}
+
+int Debug_Statistics::Get_Record_Procedural_Texture_Count()
+{
+	return last_frame_procedural_texture_count;
+}

--- a/Code/Libraries/Source/WWVegas/WW3D2/DebugStatisticsTextureMode.cpp
+++ b/Code/Libraries/Source/WWVegas/WW3D2/DebugStatisticsTextureMode.cpp
@@ -1,7 +1,7 @@
 // cl: /O2 /DNDEBUG /MD
 //
 // Debug_Statistics::Record_Texture_Mode / Get_Record_Texture_Mode,
-// retail 0x00129474 (10B) and 0x00129480 (6B).
+// retail 0x00129470 (10B) and 0x00129480 (6B).
 
 namespace Debug_Statistics
 {

--- a/Code/Libraries/Source/WWVegas/WW3D2/DebugStatisticsTextureMode.cpp
+++ b/Code/Libraries/Source/WWVegas/WW3D2/DebugStatisticsTextureMode.cpp
@@ -1,0 +1,29 @@
+// cl: /O2 /DNDEBUG /MD
+//
+// Debug_Statistics::Record_Texture_Mode / Get_Record_Texture_Mode,
+// retail 0x00129474 (10B) and 0x00129480 (6B).
+
+namespace Debug_Statistics
+{
+	enum RecordTextureMode
+	{
+		RECORD_TEXTURE_NONE,
+		RECORD_TEXTURE_SIMPLE,
+		RECORD_TEXTURE_DETAILS
+	};
+
+	void Record_Texture_Mode(RecordTextureMode mode);
+	RecordTextureMode Get_Record_Texture_Mode();
+}
+
+Debug_Statistics::RecordTextureMode record_texture_mode;
+
+void Debug_Statistics::Record_Texture_Mode(RecordTextureMode mode)
+{
+	record_texture_mode = mode;
+}
+
+Debug_Statistics::RecordTextureMode Debug_Statistics::Get_Record_Texture_Mode()
+{
+	return record_texture_mode;
+}

--- a/Code/Libraries/Source/WWVegas/WW3D2/DebugStatisticsTextureString.cpp
+++ b/Code/Libraries/Source/WWVegas/WW3D2/DebugStatisticsTextureString.cpp
@@ -1,0 +1,20 @@
+// cl: /O2 /DNDEBUG /MD
+//
+// Debug_Statistics::Get_Record_Texture_String, retail 0x00129500, 6 bytes.
+// Returns the address of the statistics string object.
+
+class StringClass
+{
+};
+
+StringClass texture_statistics_string;
+
+namespace Debug_Statistics
+{
+	const StringClass &Get_Record_Texture_String();
+}
+
+const StringClass &Debug_Statistics::Get_Record_Texture_String()
+{
+	return texture_statistics_string;
+}

--- a/Code/Libraries/Source/WWVegas/WWLib/wwstring_assign_cstr.cpp
+++ b/Code/Libraries/Source/WWVegas/WWLib/wwstring_assign_cstr.cpp
@@ -1,0 +1,36 @@
+// cl: /O1 /G7 /Oi- /DNDEBUG /MD
+//
+// StringClass::operator=(const char *), retail 0x000F0E8D, 68 bytes. Dedicated
+// TU so wwstring.cpp cannot see this definition. Calls the already-landed
+// Uninitialised_Grow, then writes the cached length and memcpy's the text.
+
+#include <string.h>
+#pragma function(strlen)
+#pragma function(memcpy)
+
+class StringClass
+{
+public:
+	const StringClass &operator=(const char *string);
+
+private:
+	void Uninitialised_Grow(int new_len);
+
+	static char *m_EmptyString;
+	char *m_Buffer;
+};
+
+char *StringClass::m_EmptyString;
+
+const StringClass &StringClass::operator=(const char *string)
+{
+	if (string != 0)
+	{
+		int len = (int)strlen(string);
+		Uninitialised_Grow(len + 1);
+		if (m_Buffer != m_EmptyString)
+			*reinterpret_cast<int *>(m_Buffer - 4) = len;
+		memcpy(m_Buffer, string, (size_t)(len + 1));
+	}
+	return *this;
+}

--- a/reverse/attempts/0x0011f3c0.cpp
+++ b/reverse/attempts/0x0011f3c0.cpp
@@ -1,0 +1,21 @@
+// ??1BFME2ScopedRenderEvent@@QAE@XZ
+// partial score=0.9 date=2026-09-10
+// cl: /O2 /DNDEBUG /MD
+//
+// BFME2ScopedRenderEvent destructor, retail 0x0011F3C0, 12 bytes. If the
+// end-event hook is set, tail-jump it; otherwise return.
+
+typedef void (*BfmeRenderEventEndFn)();
+extern BfmeRenderEventEndFn g_bfmeRenderEventEnd;
+
+class BFME2ScopedRenderEvent
+{
+public:
+	~BFME2ScopedRenderEvent();
+};
+
+BFME2ScopedRenderEvent::~BFME2ScopedRenderEvent()
+{
+	if (g_bfmeRenderEventEnd)
+		g_bfmeRenderEventEnd();
+}

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -6111,3 +6111,4 @@ _XMP_Move,,0x0061BE10,19,Code/Libraries/Source/WWVegas/WWLib/mpmath.cpp,matched,
 ?Get_Record_Texture_String@Debug_Statistics@@YAABVStringClass@@XZ,,0x00129500,6,Code/Libraries/Source/WWVegas/WW3D2/DebugStatisticsTextureString.cpp,matched,return address of texture statistics string
 ?Record_Texture_Mode@Debug_Statistics@@YAXW4RecordTextureMode@1@@Z,,0x00129470,10,Code/Libraries/Source/WWVegas/WW3D2/DebugStatisticsTextureMode.cpp,matched,store record texture mode
 ?Get_Record_Texture_Mode@Debug_Statistics@@YA?AW4RecordTextureMode@1@XZ,,0x00129480,6,Code/Libraries/Source/WWVegas/WW3D2/DebugStatisticsTextureMode.cpp,matched,return current record texture mode
+??4StringClass@@QAEABV0@PBD@Z,,0x000F0E8D,68,Code/Libraries/Source/WWVegas/WWLib/wwstring_assign_cstr.cpp,matched,strlen then Uninitialised_Grow memcpy and store length

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -6110,3 +6110,4 @@ _XMP_Move,,0x0061BE10,19,Code/Libraries/Source/WWVegas/WWLib/mpmath.cpp,matched,
 ?Get_Record_Procedural_Texture_Count@Debug_Statistics@@YAHXZ,,0x001294F0,6,Code/Libraries/Source/WWVegas/WW3D2/DebugStatisticsTextureGetters.cpp,matched,return last-frame procedural texture count
 ?Get_Record_Texture_String@Debug_Statistics@@YAABVStringClass@@XZ,,0x00129500,6,Code/Libraries/Source/WWVegas/WW3D2/DebugStatisticsTextureString.cpp,matched,return address of texture statistics string
 ?Record_Texture_Mode@Debug_Statistics@@YAXW4RecordTextureMode@1@@Z,,0x00129470,10,Code/Libraries/Source/WWVegas/WW3D2/DebugStatisticsTextureMode.cpp,matched,store record texture mode
+?Get_Record_Texture_Mode@Debug_Statistics@@YA?AW4RecordTextureMode@1@XZ,,0x00129480,6,Code/Libraries/Source/WWVegas/WW3D2/DebugStatisticsTextureMode.cpp,matched,return current record texture mode

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -6106,3 +6106,4 @@ _XMP_Move,,0x0061BE10,19,Code/Libraries/Source/WWVegas/WWLib/mpmath.cpp,matched,
 ?Get_Record_Texture_Change_Count@Debug_Statistics@@YAHXZ,,0x001294B0,6,Code/Libraries/Source/WWVegas/WW3D2/DebugStatisticsTextureGetters.cpp,matched,return last-frame texture change count
 ?Get_Record_Lightmap_Texture_Size@Debug_Statistics@@YAHXZ,,0x001294C0,6,Code/Libraries/Source/WWVegas/WW3D2/DebugStatisticsTextureGetters.cpp,matched,return last-frame lightmap texture memory
 ?Get_Record_Lightmap_Texture_Count@Debug_Statistics@@YAHXZ,,0x001294D0,6,Code/Libraries/Source/WWVegas/WW3D2/DebugStatisticsTextureGetters.cpp,matched,return last-frame lightmap texture count
+?Get_Record_Procedural_Texture_Size@Debug_Statistics@@YAHXZ,,0x001294E0,6,Code/Libraries/Source/WWVegas/WW3D2/DebugStatisticsTextureGetters.cpp,matched,return last-frame procedural texture memory

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -6107,3 +6107,4 @@ _XMP_Move,,0x0061BE10,19,Code/Libraries/Source/WWVegas/WWLib/mpmath.cpp,matched,
 ?Get_Record_Lightmap_Texture_Size@Debug_Statistics@@YAHXZ,,0x001294C0,6,Code/Libraries/Source/WWVegas/WW3D2/DebugStatisticsTextureGetters.cpp,matched,return last-frame lightmap texture memory
 ?Get_Record_Lightmap_Texture_Count@Debug_Statistics@@YAHXZ,,0x001294D0,6,Code/Libraries/Source/WWVegas/WW3D2/DebugStatisticsTextureGetters.cpp,matched,return last-frame lightmap texture count
 ?Get_Record_Procedural_Texture_Size@Debug_Statistics@@YAHXZ,,0x001294E0,6,Code/Libraries/Source/WWVegas/WW3D2/DebugStatisticsTextureGetters.cpp,matched,return last-frame procedural texture memory
+?Get_Record_Procedural_Texture_Count@Debug_Statistics@@YAHXZ,,0x001294F0,6,Code/Libraries/Source/WWVegas/WW3D2/DebugStatisticsTextureGetters.cpp,matched,return last-frame procedural texture count

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -6102,3 +6102,4 @@ _XMP_Move,,0x0061BE10,19,Code/Libraries/Source/WWVegas/WWLib/mpmath.cpp,matched,
 ?parse@?$DefaultModuleTemplate@$05@FXParticleSystem@@QAEXPAVINI@@@Z,,0x0055C434,18,Code/GameEngine/Source/GameClient/FXParticleSystemDefaultParsers.cpp,matched,BFME1 default parser transferred; BFME2 parse table at 0x00C6BB18
 ?parse@?$DefaultModuleTemplate@$0A@@FXParticleSystem@@QAEXPAVINI@@@Z,,0x0055B93F,18,Code/GameEngine/Source/GameClient/FXParticleSystemDefaultParsers.cpp,matched,BFME1 default parser transferred; BFME2 parse table at 0x00C6BA58
 ?Get_Record_Texture_Size@Debug_Statistics@@YAHXZ,,0x00129490,6,Code/Libraries/Source/WWVegas/WW3D2/DebugStatisticsTextureGetters.cpp,matched,return last-frame texture memory
+?Get_Record_Texture_Count@Debug_Statistics@@YAHXZ,,0x001294A0,6,Code/Libraries/Source/WWVegas/WW3D2/DebugStatisticsTextureGetters.cpp,matched,return last-frame texture count

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -6104,3 +6104,4 @@ _XMP_Move,,0x0061BE10,19,Code/Libraries/Source/WWVegas/WWLib/mpmath.cpp,matched,
 ?Get_Record_Texture_Size@Debug_Statistics@@YAHXZ,,0x00129490,6,Code/Libraries/Source/WWVegas/WW3D2/DebugStatisticsTextureGetters.cpp,matched,return last-frame texture memory
 ?Get_Record_Texture_Count@Debug_Statistics@@YAHXZ,,0x001294A0,6,Code/Libraries/Source/WWVegas/WW3D2/DebugStatisticsTextureGetters.cpp,matched,return last-frame texture count
 ?Get_Record_Texture_Change_Count@Debug_Statistics@@YAHXZ,,0x001294B0,6,Code/Libraries/Source/WWVegas/WW3D2/DebugStatisticsTextureGetters.cpp,matched,return last-frame texture change count
+?Get_Record_Lightmap_Texture_Size@Debug_Statistics@@YAHXZ,,0x001294C0,6,Code/Libraries/Source/WWVegas/WW3D2/DebugStatisticsTextureGetters.cpp,matched,return last-frame lightmap texture memory

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -6108,3 +6108,4 @@ _XMP_Move,,0x0061BE10,19,Code/Libraries/Source/WWVegas/WWLib/mpmath.cpp,matched,
 ?Get_Record_Lightmap_Texture_Count@Debug_Statistics@@YAHXZ,,0x001294D0,6,Code/Libraries/Source/WWVegas/WW3D2/DebugStatisticsTextureGetters.cpp,matched,return last-frame lightmap texture count
 ?Get_Record_Procedural_Texture_Size@Debug_Statistics@@YAHXZ,,0x001294E0,6,Code/Libraries/Source/WWVegas/WW3D2/DebugStatisticsTextureGetters.cpp,matched,return last-frame procedural texture memory
 ?Get_Record_Procedural_Texture_Count@Debug_Statistics@@YAHXZ,,0x001294F0,6,Code/Libraries/Source/WWVegas/WW3D2/DebugStatisticsTextureGetters.cpp,matched,return last-frame procedural texture count
+?Get_Record_Texture_String@Debug_Statistics@@YAABVStringClass@@XZ,,0x00129500,6,Code/Libraries/Source/WWVegas/WW3D2/DebugStatisticsTextureString.cpp,matched,return address of texture statistics string

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -6103,3 +6103,4 @@ _XMP_Move,,0x0061BE10,19,Code/Libraries/Source/WWVegas/WWLib/mpmath.cpp,matched,
 ?parse@?$DefaultModuleTemplate@$0A@@FXParticleSystem@@QAEXPAVINI@@@Z,,0x0055B93F,18,Code/GameEngine/Source/GameClient/FXParticleSystemDefaultParsers.cpp,matched,BFME1 default parser transferred; BFME2 parse table at 0x00C6BA58
 ?Get_Record_Texture_Size@Debug_Statistics@@YAHXZ,,0x00129490,6,Code/Libraries/Source/WWVegas/WW3D2/DebugStatisticsTextureGetters.cpp,matched,return last-frame texture memory
 ?Get_Record_Texture_Count@Debug_Statistics@@YAHXZ,,0x001294A0,6,Code/Libraries/Source/WWVegas/WW3D2/DebugStatisticsTextureGetters.cpp,matched,return last-frame texture count
+?Get_Record_Texture_Change_Count@Debug_Statistics@@YAHXZ,,0x001294B0,6,Code/Libraries/Source/WWVegas/WW3D2/DebugStatisticsTextureGetters.cpp,matched,return last-frame texture change count

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -6109,3 +6109,4 @@ _XMP_Move,,0x0061BE10,19,Code/Libraries/Source/WWVegas/WWLib/mpmath.cpp,matched,
 ?Get_Record_Procedural_Texture_Size@Debug_Statistics@@YAHXZ,,0x001294E0,6,Code/Libraries/Source/WWVegas/WW3D2/DebugStatisticsTextureGetters.cpp,matched,return last-frame procedural texture memory
 ?Get_Record_Procedural_Texture_Count@Debug_Statistics@@YAHXZ,,0x001294F0,6,Code/Libraries/Source/WWVegas/WW3D2/DebugStatisticsTextureGetters.cpp,matched,return last-frame procedural texture count
 ?Get_Record_Texture_String@Debug_Statistics@@YAABVStringClass@@XZ,,0x00129500,6,Code/Libraries/Source/WWVegas/WW3D2/DebugStatisticsTextureString.cpp,matched,return address of texture statistics string
+?Record_Texture_Mode@Debug_Statistics@@YAXW4RecordTextureMode@1@@Z,,0x00129470,10,Code/Libraries/Source/WWVegas/WW3D2/DebugStatisticsTextureMode.cpp,matched,store record texture mode

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -6105,3 +6105,4 @@ _XMP_Move,,0x0061BE10,19,Code/Libraries/Source/WWVegas/WWLib/mpmath.cpp,matched,
 ?Get_Record_Texture_Count@Debug_Statistics@@YAHXZ,,0x001294A0,6,Code/Libraries/Source/WWVegas/WW3D2/DebugStatisticsTextureGetters.cpp,matched,return last-frame texture count
 ?Get_Record_Texture_Change_Count@Debug_Statistics@@YAHXZ,,0x001294B0,6,Code/Libraries/Source/WWVegas/WW3D2/DebugStatisticsTextureGetters.cpp,matched,return last-frame texture change count
 ?Get_Record_Lightmap_Texture_Size@Debug_Statistics@@YAHXZ,,0x001294C0,6,Code/Libraries/Source/WWVegas/WW3D2/DebugStatisticsTextureGetters.cpp,matched,return last-frame lightmap texture memory
+?Get_Record_Lightmap_Texture_Count@Debug_Statistics@@YAHXZ,,0x001294D0,6,Code/Libraries/Source/WWVegas/WW3D2/DebugStatisticsTextureGetters.cpp,matched,return last-frame lightmap texture count

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -6101,3 +6101,4 @@ _XMP_Move,,0x0061BE10,19,Code/Libraries/Source/WWVegas/WWLib/mpmath.cpp,matched,
 ?parse@?$DefaultModuleTemplate@$02@FXParticleSystem@@QAEXPAVINI@@@Z,,0x0055EE4C,18,Code/GameEngine/Source/GameClient/FXParticleSystemDefaultParsers.cpp,matched,BFME1 default parser transferred; BFME2 parse table at 0x00C6C3E0
 ?parse@?$DefaultModuleTemplate@$05@FXParticleSystem@@QAEXPAVINI@@@Z,,0x0055C434,18,Code/GameEngine/Source/GameClient/FXParticleSystemDefaultParsers.cpp,matched,BFME1 default parser transferred; BFME2 parse table at 0x00C6BB18
 ?parse@?$DefaultModuleTemplate@$0A@@FXParticleSystem@@QAEXPAVINI@@@Z,,0x0055B93F,18,Code/GameEngine/Source/GameClient/FXParticleSystemDefaultParsers.cpp,matched,BFME1 default parser transferred; BFME2 parse table at 0x00C6BA58
+?Get_Record_Texture_Size@Debug_Statistics@@YAHXZ,,0x00129490,6,Code/Libraries/Source/WWVegas/WW3D2/DebugStatisticsTextureGetters.cpp,matched,return last-frame texture memory

--- a/reverse/re_attempts.log
+++ b/reverse/re_attempts.log
@@ -465,3 +465,4 @@ _bfmeDirectXErrorName@4	0x0062B16A	48672	blocked	t=15min model=gpt-6-astra; inve
 ?erase@?$vector@W4ParticleSystemID@@V?$allocator@W4ParticleSystemID@@@_STL@@@_STL@@QAEPAW4ParticleSystemID@@PAW43@0@Z	0x00532803	38	partial	compiled uses 5-arg __copy add esp 14h; retail 4-arg __copy_ptrs ICF ScienceType at 0x25BF40 with lea tag ebp+B add esp 10h score=0.7 stash=reverse/attempts/0x00532803.cpp
 ??0DrawableModule@@QAE@PAVThing@@PBVModuleData@@@Z	0x006DCD20	40	partial	prolog mov-eax vs push-mem; flags in ecx vs eax; compiled 38B vs 40B t=15min model=grok-4.6 score=0.9 stash=reverse/attempts/0x006dcd20.cpp
 ?Add@?$SimpleDynVecClass@VVector3@@@@QAE_NABVVector3@@H@Z	0x001002C5	65	partial	esi this matches; imul 0xC vs lea n*3; jz 24 vs 25 t=12min model=grok-4.6 score=0.88 stash=reverse/attempts/0x001002c5.cpp
+??1BFME2ScopedRenderEvent@@QAE@XZ	0x0011F3C0	12	partial	jnz-over-ret vs jz-then-jmp-eax t=8min model=grok-4.6 score=0.9 stash=reverse/attempts/0x0011f3c0.cpp


### PR DESCRIPTION
## Summary

Byte-exact MSVC 7.1 conversions against retail `game.dat`, one function per commit. `python tools/progress.py origin/master` reports **C++ exact +132 bytes**.

### Debug_Statistics texture surface

- `Get_Record_Texture_Size` at 0x129490 (6B)
- `Get_Record_Texture_Count` at 0x1294A0 (6B)
- `Get_Record_Texture_Change_Count` at 0x1294B0 (6B)
- `Get_Record_Lightmap_Texture_Size` at 0x1294C0 (6B)
- `Get_Record_Lightmap_Texture_Count` at 0x1294D0 (6B)
- `Get_Record_Procedural_Texture_Size` at 0x1294E0 (6B)
- `Get_Record_Procedural_Texture_Count` at 0x1294F0 (6B)
- `Get_Record_Texture_String` at 0x129500 (6B)
- `Record_Texture_Mode` at 0x129470 (10B)
- `Get_Record_Texture_Mode` at 0x129480 (6B)

### StringClass

- `StringClass::operator=(const char *)` at 0xF0E8D (68B)

Banked near-miss (not claimed): `BFME2ScopedRenderEvent` destructor at 0x11F3C0 — `jnz`-over-`ret` vs `jz`-then-`jmp eax`.

Skipped the served naked dump `d_00012190` (money_get, stash score 0.14). That file's other small bodies are already real-name gen-alias rows.

## Test plan

- [x] `python tools/check_csv.py`
- [x] `python tools/build.py` on each landed source
- [x] `python tools/progress.py origin/master`