### PR TITLE
Land 5585 bytes of byte-exact WWMath C++

### DIFF
--- a/Code/Libraries/Source/WWVegas/WWMath/Matrix3DTransformAABox.cpp
+++ b/Code/Libraries/Source/WWVegas/WWMath/Matrix3DTransformAABox.cpp
@@ -1,0 +1,72 @@
+// cl: /O2 /G7 /MD /arch:SSE
+//
+// Matrix3D::Transform_Min_Max_AABox, retail 0x00712B60, 319 bytes.
+// Dedicated TU so matrix3d.cpp keeps its matched bodies.
+
+class Vector3
+{
+public:
+	float X;
+	float Y;
+	float Z;
+	float &operator[](int i) { return (&X)[i]; }
+	const float &operator[](int i) const { return (&X)[i]; }
+};
+
+class Matrix3D
+{
+public:
+	void Transform_Min_Max_AABox(const Vector3 &min, const Vector3 &max,
+		Vector3 *set_min, Vector3 *set_max) const;
+	void Transform_Center_Extent_AABox(const Vector3 &center, const Vector3 &extent,
+		Vector3 *set_center, Vector3 *set_extent) const;
+
+	float Row[3][4];
+};
+
+void Matrix3D::Transform_Min_Max_AABox(
+	const Vector3 &min,
+	const Vector3 &max,
+	Vector3 *set_min,
+	Vector3 *set_max
+) const
+{
+	float tmp0, tmp1;
+
+	set_min->X = set_max->X = Row[0][3];
+	set_min->Y = set_max->Y = Row[1][3];
+	set_min->Z = set_max->Z = Row[2][3];
+
+	for (int i = 0; i < 3; i++) {
+		for (int j = 0; j < 3; j++) {
+			tmp0 = Row[i][j] * min[j];
+			tmp1 = Row[i][j] * max[j];
+			if (tmp0 < tmp1) {
+				(*set_min)[i] += tmp0;
+				(*set_max)[i] += tmp1;
+			} else {
+				(*set_min)[i] += tmp1;
+				(*set_max)[i] += tmp0;
+			}
+		}
+	}
+}
+
+#include <math.h>
+
+void Matrix3D::Transform_Center_Extent_AABox(
+	const Vector3 &center,
+	const Vector3 &extent,
+	Vector3 *set_center,
+	Vector3 *set_extent
+) const
+{
+	for (int i = 0; i < 3; i++) {
+		(*set_center)[i] = Row[i][3];
+		(*set_extent)[i] = 0.0f;
+		for (int j = 0; j < 3; j++) {
+			(*set_center)[i] += Row[i][j] * center[j];
+			(*set_extent)[i] += (float)fabs(Row[i][j] * extent[j]);
+		}
+	}
+}

--- a/Code/Libraries/Source/WWVegas/WWMath/Matrix3DTransformAABox.cpp
+++ b/Code/Libraries/Source/WWVegas/WWMath/Matrix3DTransformAABox.cpp
@@ -52,7 +52,12 @@ void Matrix3D::Transform_Min_Max_AABox(
 	}
 }
 
-#include <math.h>
+inline float WWMath_Fabs(float val)
+{
+	int value = *(int *)&val;
+	value &= 0x7fffffff;
+	return *(float *)&value;
+}
 
 void Matrix3D::Transform_Center_Extent_AABox(
 	const Vector3 &center,
@@ -66,7 +71,7 @@ void Matrix3D::Transform_Center_Extent_AABox(
 		(*set_extent)[i] = 0.0f;
 		for (int j = 0; j < 3; j++) {
 			(*set_center)[i] += Row[i][j] * center[j];
-			(*set_extent)[i] += (float)fabs(Row[i][j] * extent[j]);
+			(*set_extent)[i] += WWMath_Fabs(Row[i][j] * extent[j]);
 		}
 	}
 }

--- a/Code/Libraries/Source/WWVegas/WWMath/Matrix3DUnmatchedSSE.cpp
+++ b/Code/Libraries/Source/WWVegas/WWMath/Matrix3DUnmatchedSSE.cpp
@@ -1,0 +1,234 @@
+// cl: /Ireference/shims/bfmerendobj /O2 /G7 /MD /arch:SSE /DNDEBUG /Ireference/open-bfme-1/Code/Libraries/Source/WWVegas/WWLib /Ireference/open-bfme-1/Code/Libraries/Source/WWVegas/WW3D2 /Ireference/open-bfme-1/Code/Libraries/Source/WWVegas/WWMath /Ireference/open-bfme-1/Code/Libraries/Source/WWVegas/WWSaveLoad /Ireference/open-bfme-1/Code/Libraries/Source/WWVegas/Wwutil /Ireference/open-bfme-1/Code/Libraries/Source/WWVegas/WWDownload /Ireference/open-bfme-1/Code/Libraries/Source/Compression /Ireference/open-bfme-1/Code/Libraries/Source/WWVegas/WWDebug /Ireference/shims/sweep
+// Dedicated SSE TU for Matrix3D helpers that matrix3d.cpp compiles without /arch:SSE.
+
+#include "rendobj.h"
+#include "matrix3d.h"
+#include "vector3.h"
+
+#include <math.h>
+
+Vector3 Matrix3D::Rotate_Vector(const Vector3 &vect) const
+{
+	return Vector3(
+		(Row[0][0]*vect[0] + Row[0][1]*vect[1] + Row[0][2]*vect[2]),
+		(Row[1][0]*vect[0] + Row[1][1]*vect[1] + Row[1][2]*vect[2]),
+		(Row[2][0]*vect[0] + Row[2][1]*vect[1] + Row[2][2]*vect[2])
+	);
+}
+
+Vector3 Matrix3D::Inverse_Rotate_Vector(const Vector3 &vect) const
+{
+	return Vector3(
+		(Row[0][0]*vect[0] + Row[1][0]*vect[1] + Row[2][0]*vect[2]),
+		(Row[0][1]*vect[0] + Row[1][1]*vect[1] + Row[2][1]*vect[2]),
+		(Row[0][2]*vect[0] + Row[1][2]*vect[1] + Row[2][2]*vect[2])
+	);
+}
+
+void Matrix3D::Look_At(const Vector3 &p,const Vector3 &t,float roll)
+{
+	float	dx,dy,dz;
+	float	len1,len2;
+	float	sinp,cosp;
+	float	siny,cosy;
+
+	dx = (t[0] - p[0]);
+	dy = (t[1] - p[1]);
+	dz = (t[2] - p[2]);
+
+	len1 = (float)WWMath::Sqrt(dx*dx + dy*dy + dz*dz);
+	len2 = (float)WWMath::Sqrt(dx*dx + dy*dy);
+
+	if (len1 != 0.0f) {
+		sinp = dz/len1;
+		cosp = len2/len1;
+	} else {
+		sinp = 0.0f;
+		cosp = 1.0f;
+	}
+
+	if (len2 != 0.0f) {
+		siny = dy/len2;
+		cosy = dx/len2;
+	} else {
+		siny = 0.0f;
+		cosy = 1.0f;
+	}
+
+	Row[0].X = 0.0f;	Row[0].Y = 0.0f;	Row[0].Z = -1.0f;
+	Row[1].X = -1.0f;	Row[1].Y = 0.0f;	Row[1].Z = 0.0f;
+	Row[2].X = 0.0f;	Row[2].Y = 1.0f;	Row[2].Z = 0.0f;
+
+	Row[0].W = p.X;
+	Row[1].W = p.Y;
+	Row[2].W = p.Z;
+
+	Rotate_Y(siny,cosy);
+	Rotate_X(sinp,cosp);
+	Rotate_Z(-roll);
+}
+
+void Matrix3D::buildTransformMatrix( const Vector3 &pos, const Vector3 &dir )
+{
+	float sinp, cosp;
+	float siny, cosy;
+
+	float len2 = (float)sqrt( (dir.X * dir.X) + (dir.Y * dir.Y) );
+
+	sinp = dir.Z;
+	cosp = len2;
+
+	if( len2 != 0.0f )
+	{
+		siny = dir.Y / len2;
+		cosy = dir.X / len2;
+	}
+	else
+	{
+		siny = 0.0f;
+		cosy = 1.0f;
+	}
+
+	Make_Identity();
+	Translate( pos );
+	Rotate_Z( siny, cosy );
+	Rotate_Y( -sinp, cosp );
+}
+
+void Matrix3D::Obj_Look_At(const Vector3 &p,const Vector3 &t,float roll)
+{
+	float	dx,dy,dz;
+	float	len1,len2;
+	float	sinp,cosp;
+	float	siny,cosy;
+
+	dx = (t[0] - p[0]);
+	dy = (t[1] - p[1]);
+	dz = (t[2] - p[2]);
+
+	len1 = (float)sqrt(dx*dx + dy*dy + dz*dz);
+	len2 = (float)sqrt(dx*dx + dy*dy);
+
+	if (len1 != 0.0f) {
+		sinp = dz/len1;
+		cosp = len2/len1;
+	} else {
+		sinp = 0.0f;
+		cosp = 1.0f;
+	}
+
+	if (len2 != 0.0f) {
+		siny = dy/len2;
+		cosy = dx/len2;
+	} else {
+		siny = 0.0f;
+		cosy = 1.0f;
+	}
+
+	Make_Identity();
+	Translate(p);
+	Rotate_Z(siny,cosy);
+	Rotate_Y(-sinp,cosp);
+	Rotate_X(roll);
+}
+
+void Matrix3D::Copy_3x3_Matrix(float matrix[3][3])
+{
+	Row[0][0] = matrix[0][0];
+	Row[0][1] = matrix[0][1];
+	Row[0][2] = matrix[0][2];
+	Row[0][3] = 0;
+	Row[1][0] = matrix[1][0];
+	Row[1][1] = matrix[1][1];
+	Row[1][2] = matrix[1][2];
+	Row[1][3] = 0;
+	Row[2][0] = matrix[2][0];
+	Row[2][1] = matrix[2][1];
+	Row[2][2] = matrix[2][2];
+	Row[2][3] = 0;
+}
+
+int Matrix3D::Is_Orthogonal(void) const
+{
+	Vector3 x(Row[0].X,Row[0].Y,Row[0].Z);
+	Vector3 y(Row[1].X,Row[1].Y,Row[1].Z);
+	Vector3 z(Row[2].X,Row[2].Y,Row[2].Z);
+
+	if (Vector3::Dot_Product(x,y) > WWMATH_EPSILON) return 0;
+	if (Vector3::Dot_Product(y,z) > WWMATH_EPSILON) return 0;
+	if (Vector3::Dot_Product(z,x) > WWMATH_EPSILON) return 0;
+
+	if (WWMath::Fabs(x.Length2() - 1.0f) > WWMATH_EPSILON) return 0;
+	if (WWMath::Fabs(y.Length2() - 1.0f) > WWMATH_EPSILON) return 0;
+	if (WWMath::Fabs(z.Length2() - 1.0f) > WWMATH_EPSILON) return 0;
+
+	return 1;
+}
+
+void Matrix3D::Re_Orthogonalize(void)
+{
+	Vector3 x(Row[0][0],Row[0][1],Row[0][2]);
+	Vector3 y(Row[1][0],Row[1][1],Row[1][2]);
+	Vector3 z;
+
+	(Vector3::Cross_Product(x,y,&z));
+	(Vector3::Cross_Product(z,x,&y));
+
+	float len = x.Length();
+	if (len < WWMATH_EPSILON) {
+		Make_Identity();
+		return;
+	} else {
+		x *= 1.0f/len;
+	}
+
+	len = y.Length();
+	if (len < WWMATH_EPSILON) {
+		Make_Identity();
+		return;
+	} else {
+		y *= 1.0f/len;
+	}
+
+	len = z.Length();
+	if (len < WWMATH_EPSILON) {
+		Make_Identity();
+		return;
+	} else {
+		z *= 1.0f/len;
+	}
+
+	Row[0][0] = x.X;
+	Row[0][1] = x.Y;
+	Row[0][2] = x.Z;
+
+	Row[1][0] = y.X;
+	Row[1][1] = y.Y;
+	Row[1][2] = y.Z;
+
+	Row[2][0] = z.X;
+	Row[2][1] = z.Y;
+	Row[2][2] = z.Z;
+}
+
+bool Matrix3D::Solve_Linear_System(Matrix3D & system)
+{
+	if (system[0][0] == 0.0f) return false;
+	system[0] *= 1.0f / system[0][0];
+	system[1] -= system[1][0] * system[0];
+	system[2] -= system[2][0] * system[0];
+
+	if (system[1][1] == 0.0f) return false;
+	system[1] *= 1.0f / system[1][1];
+	system[2] -= system[2][1] * system[1];
+
+	if (system[2][2] == 0.0f) return false;
+	system[2] *= 1.0f / system[2][2];
+
+	system[1] -= system[1][2] * system[2];
+	system[0] -= system[0][2] * system[2];
+
+	system[0] -= system[0][1] * system[1];
+
+	return true;
+}

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -6145,3 +6145,4 @@ _strdup,,0x006C4C70,60,Code/Libraries/Source/WWVegas/WWLib/strdup.cpp,matched,in
 ?Copy_3x3_Matrix@Matrix3D@@QAEXQAY02M@Z,,0x00712B10,77,Code/Libraries/Source/WWVegas/WWMath/Matrix3DUnmatchedSSE.cpp,matched,placed by masked byte-scan of dedicated SSE TU
 ?Rotate_Vector@Matrix3D@@QBE?AVVector3@@ABV2@@Z,,0x00712030,135,Code/Libraries/Source/WWVegas/WWMath/Matrix3DUnmatchedSSE.cpp,matched,placed by masked byte-scan of dedicated SSE TU
 ?Inverse_Rotate_Vector@Matrix3D@@QBE?AVVector3@@ABV2@@Z,,0x007120C0,135,Code/Libraries/Source/WWVegas/WWMath/Matrix3DUnmatchedSSE.cpp,matched,placed by masked byte-scan of dedicated SSE TU
+??ZVector4@@QAEAAV0@ABV0@@Z,,0x00711BF0,66,Code/Libraries/Source/WWVegas/WWMath/Matrix3DUnmatchedSSE.cpp,matched,placed by masked byte-scan of dedicated SSE TU

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -6141,3 +6141,4 @@ _strdup,,0x006C4C70,60,Code/Libraries/Source/WWVegas/WWLib/strdup.cpp,matched,in
 ?Get_Single_Shader@MeshMatDescClass@@QBE?AVShaderClass@@H@Z,,0x00143370,20,Code/Libraries/Source/WWVegas/WW3D2/MeshModelClassGetSortFlagsPass.cpp,matched,Out-of-line MeshMatDesc Get_Single_Shader from get_sort_flags TU
 ??0CollectionClass@@QAE@ABV0@@Z,,0x00130C00,307,Code/Libraries/Source/WWVegas/WW3D2/CollectionClassCopyCtor.cpp,matched,Dedicated TU compiler-style copy after RenderObjClass default ctor members from plus 0xC4
 ?Transform_Min_Max_AABox@Matrix3D@@QBEXABVVector3@@0PAV2@1@Z,,0x00712B60,319,Code/Libraries/Source/WWVegas/WWMath/Matrix3DTransformAABox.cpp,matched,Dedicated TU SSE Transform_Min_Max_AABox nested interval projections
+?Transform_Center_Extent_AABox@Matrix3D@@QBEXABVVector3@@0PAV2@1@Z,,0x00712CA0,236,Code/Libraries/Source/WWVegas/WWMath/Matrix3DTransformAABox.cpp,matched,Dedicated TU SSE Transform_Center_Extent_AABox with WWMath Fabs sign-bit clear

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -6140,3 +6140,4 @@ _strdup,,0x006C4C70,60,Code/Libraries/Source/WWVegas/WWLib/strdup.cpp,matched,in
 ?Get_Single_Shader@MeshModelClass@@QBE?AVShaderClass@@H@Z,,0x001434D0,26,Code/Libraries/Source/WWVegas/WW3D2/MeshModelClassGetSortFlagsPass.cpp,matched,Out-of-line Get_Single_Shader from get_sort_flags TU
 ?Get_Single_Shader@MeshMatDescClass@@QBE?AVShaderClass@@H@Z,,0x00143370,20,Code/Libraries/Source/WWVegas/WW3D2/MeshModelClassGetSortFlagsPass.cpp,matched,Out-of-line MeshMatDesc Get_Single_Shader from get_sort_flags TU
 ??0CollectionClass@@QAE@ABV0@@Z,,0x00130C00,307,Code/Libraries/Source/WWVegas/WW3D2/CollectionClassCopyCtor.cpp,matched,Dedicated TU compiler-style copy after RenderObjClass default ctor members from plus 0xC4
+?Transform_Min_Max_AABox@Matrix3D@@QBEXABVVector3@@0PAV2@1@Z,,0x00712B60,319,Code/Libraries/Source/WWVegas/WWMath/Matrix3DTransformAABox.cpp,matched,Dedicated TU SSE Transform_Min_Max_AABox nested interval projections

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -6144,3 +6144,4 @@ _strdup,,0x006C4C70,60,Code/Libraries/Source/WWVegas/WWLib/strdup.cpp,matched,in
 ?Transform_Center_Extent_AABox@Matrix3D@@QBEXABVVector3@@0PAV2@1@Z,,0x00712CA0,236,Code/Libraries/Source/WWVegas/WWMath/Matrix3DTransformAABox.cpp,matched,Dedicated TU SSE Transform_Center_Extent_AABox with WWMath Fabs sign-bit clear
 ?Copy_3x3_Matrix@Matrix3D@@QAEXQAY02M@Z,,0x00712B10,77,Code/Libraries/Source/WWVegas/WWMath/Matrix3DUnmatchedSSE.cpp,matched,placed by masked byte-scan of dedicated SSE TU
 ?Rotate_Vector@Matrix3D@@QBE?AVVector3@@ABV2@@Z,,0x00712030,135,Code/Libraries/Source/WWVegas/WWMath/Matrix3DUnmatchedSSE.cpp,matched,placed by masked byte-scan of dedicated SSE TU
+?Inverse_Rotate_Vector@Matrix3D@@QBE?AVVector3@@ABV2@@Z,,0x007120C0,135,Code/Libraries/Source/WWVegas/WWMath/Matrix3DUnmatchedSSE.cpp,matched,placed by masked byte-scan of dedicated SSE TU

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -6150,3 +6150,4 @@ _strdup,,0x006C4C70,60,Code/Libraries/Source/WWVegas/WWLib/strdup.cpp,matched,in
 ?Rotate_Y@Matrix3D@@QAEXMM@Z,,0x00711D10,163,Code/Libraries/Source/WWVegas/WWMath/Matrix3DUnmatchedSSE.cpp,matched,placed by masked byte-scan of dedicated SSE TU
 ?Rotate_Z@Matrix3D@@QAEXMM@Z,,0x00711DC0,163,Code/Libraries/Source/WWVegas/WWMath/Matrix3DUnmatchedSSE.cpp,matched,placed by masked byte-scan of dedicated SSE TU
 ?Is_Orthogonal@Matrix3D@@QBEHXZ,,0x00712D90,416,Code/Libraries/Source/WWVegas/WWMath/Matrix3DUnmatchedSSE.cpp,matched,placed by masked byte-scan of dedicated SSE TU
+?buildTransformMatrix@Matrix3D@@QAEXABVVector3@@0@Z,,0x00712440,609,Code/Libraries/Source/WWVegas/WWMath/Matrix3DUnmatchedSSE.cpp,matched,placed by masked byte-scan of dedicated SSE TU

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -6143,3 +6143,4 @@ _strdup,,0x006C4C70,60,Code/Libraries/Source/WWVegas/WWLib/strdup.cpp,matched,in
 ?Transform_Min_Max_AABox@Matrix3D@@QBEXABVVector3@@0PAV2@1@Z,,0x00712B60,319,Code/Libraries/Source/WWVegas/WWMath/Matrix3DTransformAABox.cpp,matched,Dedicated TU SSE Transform_Min_Max_AABox nested interval projections
 ?Transform_Center_Extent_AABox@Matrix3D@@QBEXABVVector3@@0PAV2@1@Z,,0x00712CA0,236,Code/Libraries/Source/WWVegas/WWMath/Matrix3DTransformAABox.cpp,matched,Dedicated TU SSE Transform_Center_Extent_AABox with WWMath Fabs sign-bit clear
 ?Copy_3x3_Matrix@Matrix3D@@QAEXQAY02M@Z,,0x00712B10,77,Code/Libraries/Source/WWVegas/WWMath/Matrix3DUnmatchedSSE.cpp,matched,placed by masked byte-scan of dedicated SSE TU
+?Rotate_Vector@Matrix3D@@QBE?AVVector3@@ABV2@@Z,,0x00712030,135,Code/Libraries/Source/WWVegas/WWMath/Matrix3DUnmatchedSSE.cpp,matched,placed by masked byte-scan of dedicated SSE TU

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -6153,3 +6153,4 @@ _strdup,,0x006C4C70,60,Code/Libraries/Source/WWVegas/WWLib/strdup.cpp,matched,in
 ?buildTransformMatrix@Matrix3D@@QAEXABVVector3@@0@Z,,0x00712440,609,Code/Libraries/Source/WWVegas/WWMath/Matrix3DUnmatchedSSE.cpp,matched,placed by masked byte-scan of dedicated SSE TU
 ?Re_Orthogonalize@Matrix3D@@QAEXXZ,,0x00713810,663,Code/Libraries/Source/WWVegas/WWMath/Matrix3DUnmatchedSSE.cpp,matched,placed by masked byte-scan of dedicated SSE TU
 ?Look_At@Matrix3D@@QAEXABVVector3@@0M@Z,,0x00712150,737,Code/Libraries/Source/WWVegas/WWMath/Matrix3DUnmatchedSSE.cpp,matched,placed by masked byte-scan of dedicated SSE TU
+?Solve_Linear_System@Matrix3D@@SA_NAAV1@@Z,,0x00712F30,809,Code/Libraries/Source/WWVegas/WWMath/Matrix3DUnmatchedSSE.cpp,matched,placed by masked byte-scan of dedicated SSE TU

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -6151,3 +6151,4 @@ _strdup,,0x006C4C70,60,Code/Libraries/Source/WWVegas/WWLib/strdup.cpp,matched,in
 ?Rotate_Z@Matrix3D@@QAEXMM@Z,,0x00711DC0,163,Code/Libraries/Source/WWVegas/WWMath/Matrix3DUnmatchedSSE.cpp,matched,placed by masked byte-scan of dedicated SSE TU
 ?Is_Orthogonal@Matrix3D@@QBEHXZ,,0x00712D90,416,Code/Libraries/Source/WWVegas/WWMath/Matrix3DUnmatchedSSE.cpp,matched,placed by masked byte-scan of dedicated SSE TU
 ?buildTransformMatrix@Matrix3D@@QAEXABVVector3@@0@Z,,0x00712440,609,Code/Libraries/Source/WWVegas/WWMath/Matrix3DUnmatchedSSE.cpp,matched,placed by masked byte-scan of dedicated SSE TU
+?Re_Orthogonalize@Matrix3D@@QAEXXZ,,0x00713810,663,Code/Libraries/Source/WWVegas/WWMath/Matrix3DUnmatchedSSE.cpp,matched,placed by masked byte-scan of dedicated SSE TU

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -6154,3 +6154,4 @@ _strdup,,0x006C4C70,60,Code/Libraries/Source/WWVegas/WWLib/strdup.cpp,matched,in
 ?Re_Orthogonalize@Matrix3D@@QAEXXZ,,0x00713810,663,Code/Libraries/Source/WWVegas/WWMath/Matrix3DUnmatchedSSE.cpp,matched,placed by masked byte-scan of dedicated SSE TU
 ?Look_At@Matrix3D@@QAEXABVVector3@@0M@Z,,0x00712150,737,Code/Libraries/Source/WWVegas/WWMath/Matrix3DUnmatchedSSE.cpp,matched,placed by masked byte-scan of dedicated SSE TU
 ?Solve_Linear_System@Matrix3D@@SA_NAAV1@@Z,,0x00712F30,809,Code/Libraries/Source/WWVegas/WWMath/Matrix3DUnmatchedSSE.cpp,matched,placed by masked byte-scan of dedicated SSE TU
+?Obj_Look_At@Matrix3D@@QAEXABVVector3@@0M@Z,,0x007126B0,892,Code/Libraries/Source/WWVegas/WWMath/Matrix3DUnmatchedSSE.cpp,matched,placed by masked byte-scan of dedicated SSE TU

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -6149,3 +6149,4 @@ _strdup,,0x006C4C70,60,Code/Libraries/Source/WWVegas/WWLib/strdup.cpp,matched,in
 ?Rotate_X@Matrix3D@@QAEXMM@Z,,0x00711C60,165,Code/Libraries/Source/WWVegas/WWMath/Matrix3DUnmatchedSSE.cpp,matched,placed by masked byte-scan of dedicated SSE TU
 ?Rotate_Y@Matrix3D@@QAEXMM@Z,,0x00711D10,163,Code/Libraries/Source/WWVegas/WWMath/Matrix3DUnmatchedSSE.cpp,matched,placed by masked byte-scan of dedicated SSE TU
 ?Rotate_Z@Matrix3D@@QAEXMM@Z,,0x00711DC0,163,Code/Libraries/Source/WWVegas/WWMath/Matrix3DUnmatchedSSE.cpp,matched,placed by masked byte-scan of dedicated SSE TU
+?Is_Orthogonal@Matrix3D@@QBEHXZ,,0x00712D90,416,Code/Libraries/Source/WWVegas/WWMath/Matrix3DUnmatchedSSE.cpp,matched,placed by masked byte-scan of dedicated SSE TU

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -6152,3 +6152,4 @@ _strdup,,0x006C4C70,60,Code/Libraries/Source/WWVegas/WWLib/strdup.cpp,matched,in
 ?Is_Orthogonal@Matrix3D@@QBEHXZ,,0x00712D90,416,Code/Libraries/Source/WWVegas/WWMath/Matrix3DUnmatchedSSE.cpp,matched,placed by masked byte-scan of dedicated SSE TU
 ?buildTransformMatrix@Matrix3D@@QAEXABVVector3@@0@Z,,0x00712440,609,Code/Libraries/Source/WWVegas/WWMath/Matrix3DUnmatchedSSE.cpp,matched,placed by masked byte-scan of dedicated SSE TU
 ?Re_Orthogonalize@Matrix3D@@QAEXXZ,,0x00713810,663,Code/Libraries/Source/WWVegas/WWMath/Matrix3DUnmatchedSSE.cpp,matched,placed by masked byte-scan of dedicated SSE TU
+?Look_At@Matrix3D@@QAEXABVVector3@@0M@Z,,0x00712150,737,Code/Libraries/Source/WWVegas/WWMath/Matrix3DUnmatchedSSE.cpp,matched,placed by masked byte-scan of dedicated SSE TU

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -6142,3 +6142,4 @@ _strdup,,0x006C4C70,60,Code/Libraries/Source/WWVegas/WWLib/strdup.cpp,matched,in
 ??0CollectionClass@@QAE@ABV0@@Z,,0x00130C00,307,Code/Libraries/Source/WWVegas/WW3D2/CollectionClassCopyCtor.cpp,matched,Dedicated TU compiler-style copy after RenderObjClass default ctor members from plus 0xC4
 ?Transform_Min_Max_AABox@Matrix3D@@QBEXABVVector3@@0PAV2@1@Z,,0x00712B60,319,Code/Libraries/Source/WWVegas/WWMath/Matrix3DTransformAABox.cpp,matched,Dedicated TU SSE Transform_Min_Max_AABox nested interval projections
 ?Transform_Center_Extent_AABox@Matrix3D@@QBEXABVVector3@@0PAV2@1@Z,,0x00712CA0,236,Code/Libraries/Source/WWVegas/WWMath/Matrix3DTransformAABox.cpp,matched,Dedicated TU SSE Transform_Center_Extent_AABox with WWMath Fabs sign-bit clear
+?Copy_3x3_Matrix@Matrix3D@@QAEXQAY02M@Z,,0x00712B10,77,Code/Libraries/Source/WWVegas/WWMath/Matrix3DUnmatchedSSE.cpp,matched,placed by masked byte-scan of dedicated SSE TU

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -6148,3 +6148,4 @@ _strdup,,0x006C4C70,60,Code/Libraries/Source/WWVegas/WWLib/strdup.cpp,matched,in
 ??ZVector4@@QAEAAV0@ABV0@@Z,,0x00711BF0,66,Code/Libraries/Source/WWVegas/WWMath/Matrix3DUnmatchedSSE.cpp,matched,placed by masked byte-scan of dedicated SSE TU
 ?Rotate_X@Matrix3D@@QAEXMM@Z,,0x00711C60,165,Code/Libraries/Source/WWVegas/WWMath/Matrix3DUnmatchedSSE.cpp,matched,placed by masked byte-scan of dedicated SSE TU
 ?Rotate_Y@Matrix3D@@QAEXMM@Z,,0x00711D10,163,Code/Libraries/Source/WWVegas/WWMath/Matrix3DUnmatchedSSE.cpp,matched,placed by masked byte-scan of dedicated SSE TU
+?Rotate_Z@Matrix3D@@QAEXMM@Z,,0x00711DC0,163,Code/Libraries/Source/WWVegas/WWMath/Matrix3DUnmatchedSSE.cpp,matched,placed by masked byte-scan of dedicated SSE TU

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -6146,3 +6146,4 @@ _strdup,,0x006C4C70,60,Code/Libraries/Source/WWVegas/WWLib/strdup.cpp,matched,in
 ?Rotate_Vector@Matrix3D@@QBE?AVVector3@@ABV2@@Z,,0x00712030,135,Code/Libraries/Source/WWVegas/WWMath/Matrix3DUnmatchedSSE.cpp,matched,placed by masked byte-scan of dedicated SSE TU
 ?Inverse_Rotate_Vector@Matrix3D@@QBE?AVVector3@@ABV2@@Z,,0x007120C0,135,Code/Libraries/Source/WWVegas/WWMath/Matrix3DUnmatchedSSE.cpp,matched,placed by masked byte-scan of dedicated SSE TU
 ??ZVector4@@QAEAAV0@ABV0@@Z,,0x00711BF0,66,Code/Libraries/Source/WWVegas/WWMath/Matrix3DUnmatchedSSE.cpp,matched,placed by masked byte-scan of dedicated SSE TU
+?Rotate_X@Matrix3D@@QAEXMM@Z,,0x00711C60,165,Code/Libraries/Source/WWVegas/WWMath/Matrix3DUnmatchedSSE.cpp,matched,placed by masked byte-scan of dedicated SSE TU

--- a/reverse/functions.csv
+++ b/reverse/functions.csv
@@ -6147,3 +6147,4 @@ _strdup,,0x006C4C70,60,Code/Libraries/Source/WWVegas/WWLib/strdup.cpp,matched,in
 ?Inverse_Rotate_Vector@Matrix3D@@QBE?AVVector3@@ABV2@@Z,,0x007120C0,135,Code/Libraries/Source/WWVegas/WWMath/Matrix3DUnmatchedSSE.cpp,matched,placed by masked byte-scan of dedicated SSE TU
 ??ZVector4@@QAEAAV0@ABV0@@Z,,0x00711BF0,66,Code/Libraries/Source/WWVegas/WWMath/Matrix3DUnmatchedSSE.cpp,matched,placed by masked byte-scan of dedicated SSE TU
 ?Rotate_X@Matrix3D@@QAEXMM@Z,,0x00711C60,165,Code/Libraries/Source/WWVegas/WWMath/Matrix3DUnmatchedSSE.cpp,matched,placed by masked byte-scan of dedicated SSE TU
+?Rotate_Y@Matrix3D@@QAEXMM@Z,,0x00711D10,163,Code/Libraries/Source/WWVegas/WWMath/Matrix3DUnmatchedSSE.cpp,matched,placed by masked byte-scan of dedicated SSE TU


### PR DESCRIPTION
## Summary
- **+5,585 C++ exact bytes** vs `origin/master` (`python tools/progress.py origin/master`).
- Converted Matrix3D helpers that `matrix3d.cpp` could not place (that TU compiles without `/arch:SSE`) into a dedicated SSE translation unit so existing matched bodies stay untouched.

### Landed bodies
| Bytes | RVA | Symbol |
| ---: | --- | --- |
| 319 | `0x00712B60` | `Matrix3D::Transform_Min_Max_AABox` |
| 236 | `0x00712CA0` | `Matrix3D::Transform_Center_Extent_AABox` |
| 77 | `0x00712B10` | `Matrix3D::Copy_3x3_Matrix` |
| 135 | `0x00712030` | `Matrix3D::Rotate_Vector` |
| 135 | `0x007120C0` | `Matrix3D::Inverse_Rotate_Vector` |
| 66 | `0x00711BF0` | `Vector4::operator*=` |
| 165 | `0x00711C60` | `Matrix3D::Rotate_X(float, float)` |
| 163 | `0x00711D10` | `Matrix3D::Rotate_Y(float, float)` |
| 163 | `0x00711DC0` | `Matrix3D::Rotate_Z(float, float)` |
| 416 | `0x00712D90` | `Matrix3D::Is_Orthogonal` |
| 609 | `0x00712440` | `Matrix3D::buildTransformMatrix` |
| 663 | `0x00713810` | `Matrix3D::Re_Orthogonalize` |
| 737 | `0x00712150` | `Matrix3D::Look_At` |
| 809 | `0x00712F30` | `Matrix3D::Solve_Linear_System` |
| 892 | `0x007126B0` | `Matrix3D::Obj_Look_At` |

The served naked dump (`d_00012190` / wide `money_get` string `do_get`) is the known 2802-byte STLport split body already banked at score 0.14; it was not re-ground.

## Test plan
- [x] `python tools/check_csv.py`
- [x] `python tools/add_match.py` / scoped `tools/build.py` on each new source
- [x] `python tools/pin_consistency.py --check`
- [x] `python tools/progress.py origin/master` shows C++ exact **+5,585**

Made with [Cursor](https://cursor.com)