### PR TITLE
Update BFME2 reconstruction progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,15 @@ Goal: Source code that rebuilds BFME 2's engine binary (`game.dat`) byte-for-byt
 
 ## Status
 
-**3.92% of the game's retail `.text` has exact byte coverage** — 307,118 C++ bytes
-plus 9,912 ASM-only bytes. Source-backed reconstruction accounts for 3.85% of
+**8.55% of the game's retail `.text` has exact byte coverage** — 688,620 C++ bytes
+plus 3,350 ASM-only bytes. Source-backed reconstruction accounts for 8.63% of
 real code. Flag calibration is proven:
 756 Open-BFME-1 bodies transfer to `game.dat` verbatim, so the reference sweeps
 are wide open.
 
 ## Roadmap
 
-* [ ] BFME 2 Source Code (3.92%)
+* [ ] BFME 2 Source Code (8.55%)
 * [ ] 60/120 FPS
 * [ ] Memory fix
 * [ ] Better crash logs


### PR DESCRIPTION
## Summary
- Refresh README Status and Roadmap from `python tools/progress.py origin/master`.
- Retail `.text` exact coverage is now **8.55%** (688,620 C++ bytes + 3,350 ASM-only), up from 3.92%.
- Source-backed reconstruction is **8.63%** of real code (was 3.85%).

## Test plan
- [x] Numbers taken from `progress.py` on current `origin/master` (worktree delta +0)
- [ ] Confirm GitHub README renders the new Status/Roadmap percentages after merge

Made with [Cursor](https://cursor.com)